### PR TITLE
Add support for inline css styles: font-size, color; and map the 'class' attribute to word styles

### DIFF
--- a/HtmlToWord/elements/Misc.py
+++ b/HtmlToWord/elements/Misc.py
@@ -22,7 +22,7 @@ class Div(BaseElement):
     pass
 
 
-class Span(IgnoredElement):
+class Span(BaseElement):
     pass
 
 
@@ -61,5 +61,4 @@ class HyperLink(BaseElement):
             document_range = self.GetDocument().Range(Start=self.start_range,
                                                       End=self.selection.Range.End)
 
-            self.GetDocument().Hyperlinks.Add(Anchor=document_range,
-                                              Address=href)
+            self.GetDocument().Hyperlinks.Add(Anchor=document_range, Address=href)


### PR DESCRIPTION
Hi, this is a first attempt at implementing inline style support. We had to change span to inherit from BaseElement instead of IgnoredElement, because redactor and other editors apply styles by wrapping elements in a span, and otherwise it got ignored. It seemed to have no ill effects, but if we are missing something please let us know.
We also added a mapping from css 'class' to word style, since it is conceptually is very similar, and we needed to apply these to individual elements. The restriction would be that only one 'class' is supported per element, but this is a word restriction.
Colors are only accepted in rgb(x,x,x) format currently, since it's what redactor outputs, and font size only in pixels, it could be easily adapted to be more flexible, but we wanted to share this approach before putting in any more effort in this. Thanks!